### PR TITLE
Add ability to send any payload

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ Getting Started
     $ loadrunner server
 
     # In another terminal, send a sample webhook event
-    $ loadrunner send localhost:3000 myrepo push master
+    $ loadrunner event localhost:3000 myrepo push master
 
     # Verify the handler was executed
     $ cat output.txt
@@ -61,12 +61,13 @@ You can run both the server and the client using Docker.
     $ docker run -p3000:3000 dannyben/loadrunner server
 
     # Client
-    $ docker run dannyben/loadrunner send http://webhook.server.com/payload repo push
+    $ docker run dannyben/loadrunner event http://webhook.server.com/payload repo push
 
 If you wish to connect the client to the server you are running through Docker, 
 you can do something like this:
 
-    $ docker run --network host dannyben/loadrunner send http://localhost:3000/payload repo push
+    $ docker run --network host dannyben/loadrunner event http://localhost:3000/payload repo push
 
+See also: The [docker-compose file](docker-compose.yml).
 
 [1]: http://www.rubydoc.info/gems/loadrunner

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,22 @@
+version: '3'
+
+services:
+  server:
+    build: .
+    command: server
+
+    ports: ["3000:3000"]
+
+    environment:
+      RACK_ENV: production
+      GITHUB_SECRET_TOKEN:
+
+    volumes:
+      - ./handlers:/app/handlers
+
+  event:
+    build: .
+    command: event server:3000/payload myrepo push
+
+    environment:
+      GITHUB_SECRET_TOKEN:

--- a/lib/load_runner/command_line.rb
+++ b/lib/load_runner/command_line.rb
@@ -9,11 +9,21 @@ module LoadRunner
 
     version VERSION
     docopt File.expand_path 'docopt.txt', __dir__
-    subcommands [{'send' => 'send_event'}, 'status', 'server']
+    subcommands [:event, :payload, :status, :server]
 
-    def send_event
+    def event
       client = Client.new client_opts
       response = client.send_event args['EVENT'], payload_opts
+      show response
+    end
+
+    def payload
+      client = Client.new client_opts
+      file = args['FILE']
+      raise ArgumentError, "File not found: #{file}" unless File.exist? file
+
+      json = File.read file
+      response = client.send_payload args['EVENT'], json
       show response
     end
 

--- a/lib/load_runner/docopt.txt
+++ b/lib/load_runner/docopt.txt
@@ -86,7 +86,7 @@ Examples:
   loadrunner event localhost:3000/payload my_repo push refs/tags/staging
 
   # Send a payload file
-  loadrunner payload localhost:3000/payload payload.json
+  loadrunner payload localhost:3000/payload push payload.json
 
   # Start the server
   loadrunner server

--- a/lib/load_runner/docopt.txt
+++ b/lib/load_runner/docopt.txt
@@ -2,7 +2,8 @@ LoadRunner
 
 Usage:
   loadrunner server [--port N --bind IP]
-  loadrunner send URL REPO EVENT [REF --form]
+  loadrunner event URL REPO EVENT [REF --form]
+  loadrunner payload URL EVENT FILE [--form]
   loadrunner status REPO SHA STATE [--context TEXT --desc TEXT --url URL]
   loadrunner (-h|--help|--version)
 
@@ -10,8 +11,14 @@ Commands:
   server
     Start the webhook server.
 
-  send
-    Send a simulated GitHub event to a webhook server.
+  event
+    Send a simulated GitHub event to a webhook server. This will send a 
+    simplified payload, with minimal properties and is intended for testing
+    of the loadrunner server.
+
+  payload
+    Send a JSON payload file to a webhook server. To obtain a proper 
+    payload, you can copy one from your GitHub webhooks page.
 
   status
     Send status update to a github pull request.
@@ -28,6 +35,9 @@ Parameters:
 
   EVENT
     Any GitHub event, for example: push or ping.
+
+  FILE
+    A payload JSON file.
 
   REF
     A branch or tag specifier. This parameter supports four formats:
@@ -70,10 +80,13 @@ Environment Variables:
 
 Examples:
   # Simulate push events
-  loadrunner send localhost:3000/payload my_repo push master
-  loadrunner send localhost:3000/payload my_repo push branch=master
-  loadrunner send localhost:3000/payload my_repo push tag=staging --form
-  loadrunner send localhost:3000/payload my_repo push refs/tags/staging
+  loadrunner event localhost:3000/payload my_repo push master
+  loadrunner event localhost:3000/payload my_repo push branch=master
+  loadrunner event localhost:3000/payload my_repo push tag=staging --form
+  loadrunner event localhost:3000/payload my_repo push refs/tags/staging
+
+  # Send a payload file
+  loadrunner payload localhost:3000/payload payload.json
 
   # Start the server
   loadrunner server

--- a/spec/fixtures/payload.json
+++ b/spec/fixtures/payload.json
@@ -1,0 +1,6 @@
+{
+  "ref": "refs/heads/master",
+  "repository": {
+    "name": "dummy",
+  }
+}

--- a/spec/load_runner/client_spec.rb
+++ b/spec/load_runner/client_spec.rb
@@ -49,12 +49,12 @@ describe Client do
     let(:payload) { {ref: 'refs/heads/test', repository: {name: 'myrepo'}} }
     
     it "sends a post http message" do
-      expect(described_class).to receive(:post).with('', any_args)
+      expect(described_class).to receive(:post).with('/payload', any_args)
       subject.send_payload(:push, payload)
     end
 
     it "converts payload to json" do
-      expected = { body: payload.to_json, headers: { "X_GITHUB_EVENT"=>"push",  "Content-Type"=>"application/json" } }
+      expected = { body: payload.to_json, headers: { "X-GitHub-Event"=>"push",  "Content-Type"=>"application/json" } }
       expect(described_class).to receive(:post).with(anything, expected)
       subject.send_payload(:push, payload)
     end
@@ -64,7 +64,7 @@ describe Client do
 
       it "converts payload to x-www-form-urlencoded" do
         body = URI.encode_www_form({ payload: payload.to_json })
-        expected = { body: body, headers: { "X_GITHUB_EVENT"=>"push",  "Content-Type"=>"application/x-www-form-urlencoded" } }
+        expected = { body: body, headers: { "X-GitHub-Event"=>"push",  "Content-Type"=>"application/x-www-form-urlencoded" } }
         expect(described_class).to receive(:post).with(anything, expected)
         subject.send_payload(:push, payload)
       end      
@@ -78,8 +78,8 @@ describe Client do
       it "sends a signature in the header" do
         expected = { 
           headers: { 
-            "X_GITHUB_EVENT"  => "push",
-            "X_HUB_SIGNATURE" => "sha1=f2d099c2ff67f1f52e1a0b9e8445306e1d30e6e4",
+            "X-GitHub-Event"  => "push",
+            "X-Hub-Signature" => "sha1=f2d099c2ff67f1f52e1a0b9e8445306e1d30e6e4",
             "Content-Type"=>"application/json"
           },
         }

--- a/spec/load_runner/command_line_spec.rb
+++ b/spec/load_runner/command_line_spec.rb
@@ -19,13 +19,33 @@ describe CommandLine do
     end
   end
 
-  describe "send" do
-    let(:command) { %w[send my_server my_repo push] }
+  describe "event" do
+    let(:command) { %w[event my_server my_repo push] }
     let(:response) { "Dummy response" }
 
     it "sends a request" do
       expect_any_instance_of(Client).to receive(:send_event).and_return(response)
       expect {cli.execute command}.to output(/#{response}/).to_stdout
+    end
+  end
+
+  describe "payload" do
+    let(:file) { 'spec/fixtures/payload.json' }
+    let(:command) { %W[payload my_server push #{file}] }
+    let(:response) { "Dummy response" }
+    let(:json) { File.read file }
+
+    it "sends a request" do
+      expect_any_instance_of(Client).to receive(:send_payload).with('push', json).and_return(response)
+      expect {cli.execute command}.to output(/#{response}/).to_stdout
+    end
+
+    context "with an invalid file" do
+      let(:file) { 'no-such-file.json' }
+
+      it "raises ArgumentError" do
+        expect {cli.execute command}.to raise_error(ArgumentError)
+      end
     end
   end
 


### PR DESCRIPTION
This PR:

- Renames the `loadrunner send` command to `loadrunner event`
- Adds `loadrunner payload` command to send any payload file
- Adds a sample `docker-compose.yml`
- Fixes the client to be able to handle paths that end with a `/`
- Changes (fixes?) GitHub headers - used to be all caps, but this did not work well with Jenkins
