### PR TITLE
Updates (breaking changes)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,4 +5,5 @@
 /Gemfile.lock
 /.yardoc
 /output.txt
+/last_payload.json
 *.gem

--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ Getting Started
 3. Start the server (from the `hooks` **parent** directory):
    `loadrunner server`
 4. In another terminal, send a sample webhook event:
-   `loadrunner event localhost:3000/payload myrepo push master
+   `loadrunner event localhost:3000 myrepo push master
 
 The server should respond with a detailed JSON response, specifying what
 hooks were executed (`executed_hooks`) and what hooks *could have
@@ -89,9 +89,9 @@ These environment variables are available to your hooks:
 - `LOADRUNNER_REPO`
 - `LOADRUNNER_EVENT`
 - `LOADRUNNER_BRANCH`
+- `LOADRUNNER_COMMIT`
 - `LOADRUNNER_REF`
 - `LOADRUNNER_TAG`
-- `LOADRUNNER_PAYLOAD` - the entire JSON string as received from GitHub, or the client.
 
 
 
@@ -104,7 +104,7 @@ application, use the `Loadrunner::Server` as the handler.
 
 ```ruby
 # config.ru
-require "loadrunner"
+require "loadrunner/server"
 
 map "/github" do
   run Loadrunner::Server
@@ -118,29 +118,24 @@ run YourOwnApp
 Sending Pull Request status from Ruby code
 --------------------------------------------------
 
-You may use the `Loadrunner::GithubAPI` class to update the status of a
+You may use the `Loadrunner::Status` class to update the status of a
 GitHub pull request.
 
 First, make sure that your GitHub API access token is set in the environment
 variable `GITHUB_ACCESS_TOKEN`.
 
 ```ruby
-require 'loadrunner/github_api'
+require 'loadrunner/status'
 
-api = Loadrunner::GithubAPI.new
-
-opts = {
-  state:       :pending,  # :pending :success :failure :error
-  target_url:  "http://example.com", 
-  context:     "My Hooks Server", 
-  description: "Jobs have not started yet"
-}
-
-repo = "user/repo"
-sha = "commit sha string"
-
-response = api.status repo, sha, opts
+response = Loadrunner::Status.update repo: 'user/repo', 
+  sha: 'commit sha string', 
+  state: :pending,  # :pending :success :failure :error
+  context: "My Hooks Server",
+  description: "Jobs have not started yet",
+  url: "http://example.com"
 ```
+
+Only `repo`, `sha` and `state` are required, the rest arguments are optional.
 
 
 
@@ -154,14 +149,14 @@ You can run both the server and the client using Docker.
 $ docker run -p3000:3000 dannyben/loadrunner server
 
 # Client
-$ docker run dannyben/loadrunner event http://webhook.server.com/payload repo push
+$ docker run dannyben/loadrunner event http://webhook.server.com repo push
 ```
 
 If you wish to connect the client to the server you are running through Docker, 
 you can do something like this:
 
 ```shell
-$ docker run --network host dannyben/loadrunner event http://localhost:3000/payload repo push
+$ docker run --network host dannyben/loadrunner event http://localhost:3000 repo push
 ```
 
 See also: The [docker-compose file](docker-compose.yml).

--- a/bin/loadrunner
+++ b/bin/loadrunner
@@ -1,6 +1,7 @@
 #!/usr/bin/env ruby
 
 require 'loadrunner'
+require 'loadrunner/command_line'
 
 begin
   Loadrunner::CommandLine.execute ARGV

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -22,7 +22,7 @@ services:
 
   event:
     build: .
-    command: event server:3000/payload myrepo push
+    command: event server:3000 myrepo push
 
     environment:
       GITHUB_SECRET_TOKEN:

--- a/hooks/global
+++ b/hooks/global
@@ -6,7 +6,7 @@ puts "This hook is called on all events"
 
 env_vars = [
   'LOADRUNNER_REPO', 'LOADRUNNER_EVENT', 'LOADRUNNER_BRANCH', 
-  'LOADRUNNER_REF', 'LOADRUNNER_TAG', 'LOADRUNNER_PAYLOAD'
+  'LOADRUNNER_REF', 'LOADRUNNER_TAG', 'LOADRUNNER_COMMIT'
 ]
 
 env_vars.each do |varname|

--- a/hooks/myrepo/global
+++ b/hooks/myrepo/global
@@ -6,7 +6,7 @@ puts "This hook is called on all events in this repo"
 
 env_vars = [
   'LOADRUNNER_REPO', 'LOADRUNNER_EVENT', 'LOADRUNNER_BRANCH', 
-  'LOADRUNNER_REF', 'LOADRUNNER_TAG', 'LOADRUNNER_PAYLOAD'
+  'LOADRUNNER_REF', 'LOADRUNNER_TAG', 'LOADRUNNER_COMMIT'
 ]
 
 env_vars.each do |varname|

--- a/hooks/myrepo/push
+++ b/hooks/myrepo/push
@@ -6,7 +6,7 @@ puts "This hook is called on all pushes in this repo"
 
 env_vars = [
   'LOADRUNNER_REPO', 'LOADRUNNER_EVENT', 'LOADRUNNER_BRANCH', 
-  'LOADRUNNER_REF', 'LOADRUNNER_TAG', 'LOADRUNNER_PAYLOAD'
+  'LOADRUNNER_REF', 'LOADRUNNER_TAG', 'LOADRUNNER_COMMIT'
 ]
 
 env_vars.each do |varname|

--- a/hooks/myrepo/push@branch=master
+++ b/hooks/myrepo/push@branch=master
@@ -6,7 +6,7 @@ puts "This hook is called when pushing to master"
 
 env_vars = [
   'LOADRUNNER_REPO', 'LOADRUNNER_EVENT', 'LOADRUNNER_BRANCH', 
-  'LOADRUNNER_REF', 'LOADRUNNER_TAG', 'LOADRUNNER_PAYLOAD'
+  'LOADRUNNER_REF', 'LOADRUNNER_TAG', 'LOADRUNNER_COMMIT'
 ]
 
 env_vars.each do |varname|

--- a/hooks/myrepo/push@tag=mytag
+++ b/hooks/myrepo/push@tag=mytag
@@ -6,7 +6,7 @@ puts "This hook is called when there is a specific tag"
 
 env_vars = [
   'LOADRUNNER_REPO', 'LOADRUNNER_EVENT', 'LOADRUNNER_BRANCH', 
-  'LOADRUNNER_REF', 'LOADRUNNER_TAG', 'LOADRUNNER_PAYLOAD'
+  'LOADRUNNER_REF', 'LOADRUNNER_TAG', 'LOADRUNNER_COMMIT'
 ]
 
 env_vars.each do |varname|

--- a/lib/loadrunner.rb
+++ b/lib/loadrunner.rb
@@ -1,13 +1,4 @@
-require 'loadrunner/version'
-
-require 'loadrunner/signature_helper'
-require 'loadrunner/server_helper'
-require 'loadrunner/github_api'
-
-require 'loadrunner/runner'
-require 'loadrunner/server_base'
 require 'loadrunner/server'
-
 require 'loadrunner/client'
 require 'loadrunner/command_line'
 

--- a/lib/loadrunner/client.rb
+++ b/lib/loadrunner/client.rb
@@ -12,7 +12,7 @@ module Loadrunner
       @secret_token = opts[:secret_token]
       @encoding = opts[:encoding] || :json
 
-      base_url = opts[:base_url] || 'http://localhost:3000/payload'
+      base_url = opts[:base_url] || 'http://localhost:3000'
       base_url = "http://#{base_url}" unless base_url =~ /^http/
 
       url_parts = URI.parse base_url

--- a/lib/loadrunner/command_line.rb
+++ b/lib/loadrunner/command_line.rb
@@ -1,5 +1,9 @@
 require 'super_docopt'
 require 'colsole'
+require 'loadrunner/client'
+require 'loadrunner/server'
+require 'loadrunner/status'
+require 'loadrunner/version'
 
 module Loadrunner
 
@@ -33,15 +37,12 @@ module Loadrunner
     end
 
     def status
-      api = GithubAPI.new
-      opts = {
-        state:       args['STATE'], 
-        target_url:  args['--url'], 
-        context:     args['--context'], 
-        description: args['--desc']
-      }
-
-      response = api.status args['REPO'], args['SHA'], opts
+      response = Status.update repo: args['REPO'], 
+        sha: args['SHA'], 
+        state: args['STATE'], 
+        context: args['--context'],
+        description: args['--desc'],
+        url: args['--url']
 
       show response
     end

--- a/lib/loadrunner/docopt.txt
+++ b/lib/loadrunner/docopt.txt
@@ -27,7 +27,7 @@ Parameters:
   URL
     The URL of the webhook endpoint. This path should responds
     to POST requests. If you are sending an event to a loadrunner server,
-    send it to the /payload endpoint (e.g. localhost:3000/payload).
+    send it to the root endpoint (e.g. localhost:3000).
 
   REPO
     The name of the repository. This can be either the short name 
@@ -80,13 +80,13 @@ Environment Variables:
 
 Examples:
   # Simulate push events
-  loadrunner event localhost:3000/payload myrepo push master
-  loadrunner event localhost:3000/payload myrepo push branch=master
-  loadrunner event localhost:3000/payload myrepo push tag=staging --form
-  loadrunner event localhost:3000/payload myrepo push refs/tags/staging
+  loadrunner event localhost:3000 myrepo push master
+  loadrunner event localhost:3000 myrepo push branch=master
+  loadrunner event localhost:3000 myrepo push tag=staging --form
+  loadrunner event localhost:3000 myrepo push refs/tags/staging
 
   # Send a payload file
-  loadrunner payload localhost:3000/payload push payload.json
+  loadrunner payload localhost:3000 push payload.json
 
   # Start the server
   loadrunner server

--- a/lib/loadrunner/server.rb
+++ b/lib/loadrunner/server.rb
@@ -1,3 +1,8 @@
+require 'loadrunner/server_helper'
+require 'loadrunner/server_base'
+require 'loadrunner/signature_helper'
+require 'loadrunner/runner'
+
 module Loadrunner
 
   # The Sinatra server
@@ -6,10 +11,10 @@ module Loadrunner
     include SignatureHelper
 
     get '/' do
-      "OK"
+      "loadrunner ready"
     end
 
-    post '/payload' do
+    post '/' do
       request.body.rewind
       payload_body = request.body.read
 
@@ -27,11 +32,13 @@ module Loadrunner
 
       opts = {}
       opts[:repo]    = payload.dig('repository', 'name')
+      opts[:commit]  = payload['after']
       opts[:event]   = request.env['HTTP_X_GITHUB_EVENT']
       opts[:ref]     = payload['ref']
       opts[:branch]  = payload['ref'] =~ /refs\/heads/ ? payload['ref'].sub('refs/heads/', '') : nil
       opts[:tag]     = payload['ref'] =~ /refs\/tags/ ? payload['ref'].sub('refs/tags/', '') : nil
-      opts[:payload] = json_string
+
+      File.write "last_payload.json", json_string if ENV['DEBUG']
 
       runner = Runner.new opts
       success = runner.execute

--- a/lib/loadrunner/status.rb
+++ b/lib/loadrunner/status.rb
@@ -1,0 +1,21 @@
+require 'loadrunner/github_api'
+
+module Loadrunner
+  # Update GitHub pull request status
+  class Status
+    class << self
+      def update(repo:, sha:, state:, context: nil, description: nil, url: nil)
+        api = GithubAPI.new
+
+        opts = {
+          state: state,
+          target_url:  url,
+          context: context,
+          description: description
+        }
+
+        api.status repo, sha, opts
+      end
+    end
+  end
+end

--- a/spec/loadrunner/client_spec.rb
+++ b/spec/loadrunner/client_spec.rb
@@ -49,7 +49,7 @@ describe Client do
     let(:payload) { {ref: 'refs/heads/test', repository: {name: 'myrepo'}} }
     
     it "sends a post http message" do
-      expect(described_class).to receive(:post).with('/payload', any_args)
+      expect(described_class).to receive(:post).with('', any_args)
       subject.send_payload(:push, payload)
     end
 

--- a/spec/loadrunner/server_spec.rb
+++ b/spec/loadrunner/server_spec.rb
@@ -4,10 +4,10 @@ describe Server do
   it "works" do
     get '/'
     expect(last_response).to be_ok
-    expect(last_response.body).to eq "OK"
+    expect(last_response.body).to eq "loadrunner ready"
   end
 
-  describe "/payload" do
+  describe "POST /" do
     let(:payload) { {key: 'value'}.to_json }
 
     context "with a json request" do
@@ -15,7 +15,7 @@ describe Server do
 
       it "executes the runner" do
         expect_any_instance_of(Runner).to receive(:execute)
-        post '/payload', payload, header
+        post '/', payload, header
       end
     end
 
@@ -25,7 +25,7 @@ describe Server do
 
       it "executes the runner" do
         expect_any_instance_of(Runner).to receive(:execute)
-        post '/payload', payload, header
+        post '/', payload, header
       end
     end
 
@@ -40,7 +40,7 @@ describe Server do
 
       it "halts with 401" do
         expect_any_instance_of(Runner).not_to receive(:execute)
-        post '/payload', payload
+        post '/', payload
         expect(last_response.status).to be 401
         expect(last_response.body).to eq halt_messages[:no_client]
       end

--- a/spec/loadrunner/status_spec.rb
+++ b/spec/loadrunner/status_spec.rb
@@ -1,0 +1,15 @@
+require 'spec_helper'
+
+describe Status do
+  subject { described_class }
+
+  describe "status" do
+    let(:expected) { OpenStruct.new code: 200 }
+
+    it "calls GitHub API" do
+      expect_any_instance_of(GithubAPI).to receive(:status).and_return(expected)
+      actual = subject.update repo: 'repo', sha: 'sha', state: 'pending'
+      expect(actual).to eq expected
+    end
+  end
+end


### PR DESCRIPTION
### Breaking changes:

- Change payload endpoint from `/payload` to `/`.
- Remove `LOADRUNNER_PAYLOAD` environment variable.

### Other changes:

- Change the string that `GET /` returns from `OK` to `loadrunner ready`.
- Add `LOADRUNNER_COMMIT` environment variable, that returns the GitHub commit SHA.
- Reorganize all `require` calls, so that users who want to include loadrunner modules, can `require 'loadrunner/server'` and `require 'loadrunner/status'`.
- Add `Loadrunner::Status` module, for users who want to send status updates from Ruby code.
- When the environment variable `DEBUG` is set, the last server payload will be written to `last_payload.json`.

