### PR TITLE
Add repo@tag hook to handle all tags

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ statuses.
 
 It provides these features:
 
-- A webserver that responds to GitHub webhook events and can run any 
+- A web server that responds to GitHub webhook events and can run any 
   arbitrary script written in any language.
 - A command line utility for testing your webhook server configuration by
   sending simulated events.
@@ -35,8 +35,8 @@ Getting Started
 --------------------------------------------------
 
 1. Download the [hooks](hooks) directory from this repository, as an
-   exmaple. This directory contains several hook examples.
-2. Make sure that all files within that folder are executables.
+   example. This directory contains several hook examples.
+2. Make sure that all files within that folder are executable.
 3. Start the server (from the `hooks` **parent** directory):
    `loadrunner server`
 4. In another terminal, send a sample webhook event:
@@ -66,7 +66,8 @@ the `./hooks` directory, using one of these format:
     hooks/<repo name>/global
     hooks/<repo name>/<event type>
     hooks/<repo name>/<event type>@branch=<branch name>
-    hooks/<repo name>/<event type>@tag=<branch name>
+    hooks/<repo name>/<event type>@tag=<tag name>
+    hooks/<repo name>/<event type>@tag
 
 For example:
 
@@ -75,12 +76,13 @@ For example:
     hooks/myrepo/push
     hooks/myrepo/push@branch=master
     hooks/myrepo/push@tag=release
+    hooks/myrepo/push@tag
 
 When none of the hooks are found, Loadrunner will respond with a list of
 hooks it was looking for, so you can use this response to figure out what
 it needs.
 
-The hooks can be written in any language, and should simply be executables.
+The hooks can be written in any language, and should simply be executable.
 
 ### Environment Variables
 

--- a/lib/loadrunner/runner.rb
+++ b/lib/loadrunner/runner.rb
@@ -63,17 +63,21 @@ module Loadrunner
 
     def matching_hooks
       base = "#{hooks_dir}/#{opts[:repo]}/#{opts[:event]}"
+
       hooks = [
         "#{hooks_dir}/global",
         "#{hooks_dir}/#{opts[:repo]}/global",
         "#{base}"
       ]
 
-      hooks.tap do |h|
-        h << "#{base}@branch=#{opts[:branch]}" if opts[:branch]
-        h << "#{base}@tag=#{opts[:tag]}" if opts[:tag]
-        h << "#{base}@tag" if opts[:tag]
+      hooks << "#{base}@branch=#{opts[:branch]}" if opts[:branch]
+      
+      if opts[:tag]
+        hooks << "#{base}@tag=#{opts[:tag]}" 
+        hooks << "#{base}@tag"
       end
+
+      hooks
     end
 
   end

--- a/lib/loadrunner/runner.rb
+++ b/lib/loadrunner/runner.rb
@@ -72,6 +72,7 @@ module Loadrunner
       hooks.tap do |h|
         h << "#{base}@branch=#{opts[:branch]}" if opts[:branch]
         h << "#{base}@tag=#{opts[:tag]}" if opts[:tag]
+        h << "#{base}@tag" if opts[:tag]
       end
     end
 

--- a/spec/loadrunner/runner_spec.rb
+++ b/spec/loadrunner/runner_spec.rb
@@ -62,12 +62,26 @@ describe Runner do
         expect(actual).to eq expected
       end
 
+      it "returns matching hooks list" do
+        subject.execute
+        actual = subject.response[:matching_hooks]
+        expected = [
+          "spec/fixtures/hooks/global",
+          "spec/fixtures/hooks/myrepo/global",
+          "spec/fixtures/hooks/myrepo/push",
+          "spec/fixtures/hooks/myrepo/push@tag=production",
+          "spec/fixtures/hooks/myrepo/push@tag"
+        ]
+        expect(actual).to eq expected
+      end
+
       it "executes the hooks" do
         File.delete 'secret.txt' if File.exist? 'secret.txt'
         subject.execute
         sleep 2
         expect(File.read 'secret.txt').to eq "There is no spoon\n"
       end
+
     end
 
   end


### PR DESCRIPTION
Implementing a regex or glob pattern tag, as suggested in #18, would be awkward, since the hooks are files, and we cannot use some characters needed for globbing in a filename.

Instead, this PR adds a `repo@tag` hook, which will be called whenever the commit is tagged. The user can then do whatever checks on the `LOADRUNNER_TAG` and act accordingly.

Good enough compromise for now.

Closes #18 