### PR TITLE
Add explicit dependencies for Ruby 3.3

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,8 +1,13 @@
-FROM dannyben/alpine-ruby
+FROM dannyben/alpine-ruby:3.2.2
+
+ENV MADNESS_VERSION=0.4.4
 
 WORKDIR /app
 
-RUN gem install json loadrunner
+VOLUME /app
+
+RUN gem install bashly --version $MADNESS_VERSION && \
+    gem update --system
 
 EXPOSE 3000
 

--- a/lib/loadrunner/github_api.rb
+++ b/lib/loadrunner/github_api.rb
@@ -17,7 +17,7 @@ module Loadrunner
       message = {
         body: {
           state:       (opts[:state] ? opts[:state].to_s : 'pending'),
-          context:     (opts[:context] || 'Loadrunner'),
+          context:     opts[:context] || 'Loadrunner',
           description: opts[:description],
           target_url:  opts[:target_url],
         }.to_json,

--- a/loadrunner.gemspec
+++ b/loadrunner.gemspec
@@ -15,12 +15,16 @@ Gem::Specification.new do |s|
   s.license     = 'MIT'
   s.required_ruby_version = '>= 3.0'
 
-  s.add_runtime_dependency 'colsole', '>= 0.8.1', '< 2.0'
-  s.add_runtime_dependency 'httparty', '~> 0.21'
-  s.add_runtime_dependency 'puma', '~> 6.0'
-  s.add_runtime_dependency 'sinatra', '>= 3.0', '< 5'
-  s.add_runtime_dependency 'sinatra-contrib', '>= 3.0', '< 5'
-  s.add_runtime_dependency 'super_docopt', '~> 0.1'
+  s.add_dependency 'colsole', '>= 0.8.1', '< 2.0'
+  s.add_dependency 'httparty', '~> 0.21'
+  s.add_dependency 'puma', '~> 6.0'
+  s.add_dependency 'sinatra', '>= 3.0', '< 5'
+  s.add_dependency 'sinatra-contrib', '>= 3.0', '< 5'
+  s.add_dependency 'super_docopt', '~> 0.1'
+
+  # REMOVE ME
+  s.add_dependency 'bigdecimal', '>= 0'  # to address ruby warning by multi_xml
+  s.add_dependency 'csv', '>= 0'         # to address ruby warning by httparty
 
   s.metadata = {
     'bug_tracker_uri'       => 'https://github.com/DannyBen/loadrunner/issues',


### PR DESCRIPTION
The `multi_xml` and `httparty` gems are currently not bringing the dependencies they need - namely, `bigdecimal` and `csv`.
This PR adds these gems to the gemspec temporarily, until theses gems are released with the proper gemspec.